### PR TITLE
ipq807x: fix gl-ax1800 switch button high active level

### DIFF
--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq6018-gl-ax1800.dtsi
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq6018-gl-ax1800.dtsi
@@ -262,7 +262,7 @@
 		switch {
 			label = "switch";
 			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
+			gpios = <&tlmm 9 GPIO_ACTIVE_HIGH>;
 			linux,input-type = <1>;
 			debounce-interval = <60>;
 		};


### PR DESCRIPTION
The active status of the switch button in the DTS configuration
is the opposite of that marked on the product housing.

The switch button should be activated at high GPIO level.

Signed-off-by: GL.iNet-Xinfa.Deng <xinfa.deng@gl-inet.com>